### PR TITLE
remove patch and update fluentd-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,9 @@
-# Use patched reloader. Can be removed after version with fix (https://github.com/vmware/kube-fluentd-operator/pull/360) is available.
-FROM golang:1.18 as builder
-WORKDIR /go/src/github.com/vmware/kube-fluentd-operator
-RUN set -e \
- && git clone --depth 1 --branch bugfix/migration-mode-with-cr-namespaces https://github.com/jonasrutishauser/kube-fluentd-operator.git . \
- && cd config-reloader \
- && GO111MODULE=on GOARCH=amd64 CGO_ENABLED=0 go build -v -ldflags "-X github.com/vmware/kube-fluentd-operator/config-reloader/config.Version=1.16.8-1 -w -s" .
-# End patch build
-
-FROM vmware/kube-fluentd-operator:v1.16.8
+FROM vmware/kube-fluentd-operator:v1.17.6
 
 RUN set -e \
  && tdnf install -y jq sed \
  && gem install -N fluent-plugin-jq -v "0.5.1" \
  && echo OK
-
-# Use patched reloader
-COPY --from=builder /go/src/github.com/vmware/kube-fluentd-operator/config-reloader/config-reloader /bin/config-reloader
 
 # Patch configuration files:
 # - relabel all at end to allow default match in kube-system.conf (is before all other namespaces)


### PR DESCRIPTION
Issue #8 - Remove patch inclusion and use at least version 1.17.0 of kube-fluentd-operator